### PR TITLE
Fixing cmake developer warning (#972)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,7 +29,7 @@ jobs:
           echo "Emulator starting"
 
       - name: Configure
-        run: cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=16 -DANDROID_ABI=x86_64 -DCMAKE_BUILD_TYPE=Debug ..
+        run: cmake -Werror=dev -DCMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk-bundle/build/cmake/android.toolchain.cmake -DANDROID_PLATFORM=16 -DANDROID_ABI=x86_64 -DCMAKE_BUILD_TYPE=Debug ..
 
       - name: Build
         run: cmake --build . --parallel

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Configure
         run: |
           cmake \
+            -Werror=dev \
             -GXcode \
             -DCMAKE_SYSTEM_NAME=iOS \
             "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64" \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(GSL
     LANGUAGES CXX
 )
 
+# Must include after the project call due to GNUInstallDirs requiring a language be enabled (IE. CXX)
+include(GNUInstallDirs)
+
 # Creates a library GSL which is an interface (header files only)
 add_library(GSL INTERFACE)
 

--- a/cmake/guidelineSupportLibrary.cmake
+++ b/cmake/guidelineSupportLibrary.cmake
@@ -16,9 +16,6 @@ endif()
 # Necessary for 'write_basic_package_version_file'
 include(CMakePackageConfigHelpers)
 
-# Use GNUInstallDirs to provide the right locations on all platforms
-include(GNUInstallDirs)
-
 function(gsl_set_default_cxx_standard min_cxx_standard)
     set(GSL_CXX_STANDARD "${min_cxx_standard}" CACHE STRING "Use c++ standard")
 

--- a/pipelines/steps.yml
+++ b/pipelines/steps.yml
@@ -3,7 +3,7 @@ steps:
     name: Configure
     inputs:
       workingDirectory: build
-      cmakeArgs: '-DCMAKE_CXX_STANDARD=$(GSL_CXX_STANDARD) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) .. '
+      cmakeArgs: '-DCMAKE_CXX_STANDARD=$(GSL_CXX_STANDARD) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -Werror=dev .. '
 
   - task: CMake@1
     name: Build


### PR DESCRIPTION
Here is the warning currently being produced:

CMake Warning (dev) at C:/Program Files/CMake/share/cmake-3.19/Modules/GNUInstallDirs.cmake:223 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
Call Stack (most recent call first):
  cmake/guidelineSupportLibrary.cmake:20 (include)
  CMakeLists.txt:4 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

I noted how I fixed the error. This is caused by GNUInstallDirs automatically executing code just by including it.

I also added -Werror=dev to the CI to ensure this never happens again.

Co-authored-by: Juan Ramos <juanr0911@gmail.com>